### PR TITLE
Provided empty callback function since modbus-serial relies on

### DIFF
--- a/lib/modbus_util.ts
+++ b/lib/modbus_util.ts
@@ -32,7 +32,7 @@ export class ModbusConnection {
 
     close() {
         // @ts-ignore
-        this.client.close()
+        this.client.close(()=>{});
     }
 
     async readModbus(register: number, dtype: ModbusDatatype, length?: number): Promise<any> {


### PR DESCRIPTION
#1: modbus-serial relies on a callback function.

Not providing a callback function in modbus_util.js close leads to the "Callback is not a function error".